### PR TITLE
fix: trigger release workflow after tag push

### DIFF
--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -102,6 +102,12 @@ jobs:
           git commit -m "chore: bump OpenClaw to ${{ steps.get-version.outputs.version }}"
           git tag "v${{ steps.new-version.outputs.new_version }}"
           git push && git push --tags
+      - name: Trigger release workflow
+        if: steps.check.outputs.skip != 'true' && inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ secrets.THEPAGENT_PAT }}
+        run: |
+          gh workflow run release.yml --repo ${{ github.repository }} --ref "v${{ steps.new-version.outputs.new_version }}" -f tag="v${{ steps.new-version.outputs.new_version }}"
       - name: Set up Helm
         if: steps.check.outputs.skip != 'true' && inputs.dry_run != true
         uses: azure/setup-helm@v4


### PR DESCRIPTION
PAT-authenticated tag pushes don't trigger other workflows when the PAT belongs to the same account as the repo owner. This causes `release.yml` to never fire after `check-upstream.yml` pushes a new tag.

Fix: explicitly call `gh workflow run release.yml` after the tag push using `THEPAGENT_PAT`.
