### PR TITLE
fix: use main ref for release workflow_dispatch

### DIFF
--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -107,7 +107,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.THEPAGENT_PAT }}
         run: |
-          gh workflow run release.yml --repo ${{ github.repository }} --ref "v${{ steps.new-version.outputs.new_version }}" -f tag="v${{ steps.new-version.outputs.new_version }}"
+          gh workflow run release.yml --repo ${{ github.repository }} --ref main -f tag="v${{ steps.new-version.outputs.new_version }}"
       - name: Set up Helm
         if: steps.check.outputs.skip != 'true' && inputs.dry_run != true
         uses: azure/setup-helm@v4


### PR DESCRIPTION
`gh workflow run` 的 `--ref` 參數需要分支名稱，傳入 tag 名稱會導致失敗。改為使用 `main`。