### PR TITLE
docs: add Zeabur deployment options comparison (Template vs Helm)

### DIFF
--- a/docs/zeabur_options.md
+++ b/docs/zeabur_options.md
@@ -1,6 +1,6 @@
 # Deploying OpenClaw on Zeabur: Template vs Helm Chart
 
-Zeabur offers two ways to run OpenClaw. This document compares them to help you choose.
+[Zeabur](https://zeabur.com/) has become one of the popular VPS providers, offering a curated collection of self-baked one-click templates as well as K3s-ready instances out of the box. This makes it a natural fit for running OpenClaw — and it offers two distinct ways to do so. This document compares them to help you choose.
 
 ## Options at a Glance
 


### PR DESCRIPTION
## Summary

Adds `docs/zeabur_options.md` — a comparison guide for the two ways to run OpenClaw on Zeabur:

1. **Zeabur Template** (one-click, zero K8s knowledge required)
2. **openclaw-helm on Zeabur K3s** (recommended for security-conscious users)

## What's covered

- Side-by-side feature table (version, security, credentials, upgrade UX)
- Decision guide: when to use each option
- Recommended setup for openclaw-helm on Zeabur K3s
- Known limitations of both options (SSO, HA, audit log)

## Key insight

Zeabur's built-in K3s means users can run the Helm chart on the same platform — getting Zeabur's managed infrastructure **and** the Helm chart's stricter security posture, making the Zeabur Template largely redundant for anyone comfortable with `helm install`.
