### PR TITLE
feat: add Chrome browser deps init container with CJK fonts

### DIFF
--- a/charts/openclaw-helm/templates/deployment.yaml
+++ b/charts/openclaw-helm/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           mountPath: /home/node/.openclaw
         - name: tmp
           mountPath: /tmp
-      
+
       - name: init-skills
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         command:
@@ -54,7 +54,38 @@ spec:
           mountPath: /home/node/.openclaw
         - name: tmp
           mountPath: /tmp
-      
+
+      {{- if .Values.config.browser.enabled }}
+      - name: install-chrome-deps
+        image: "{{ .Values.browser.depsImage | default "debian:12" }}"
+        securityContext:
+          runAsUser: 0
+        command:
+        - sh
+        - -c
+        - |
+          apt-get update -qq && apt-get install -y -qq \
+            libxcb-shm0 libx11-xcb1 libx11-6 libxcb1 libxext6 libxrandr2 \
+            libxcomposite1 libxcursor1 libxdamage1 libxfixes3 libxi6 libgtk-3-0 \
+            libpangocairo-1.0-0 libpango-1.0-0 libatk1.0-0 libcairo-gobject2 \
+            libcairo2 libgdk-pixbuf-2.0-0 libxrender1 libasound2t64 libfreetype6 \
+            libfontconfig1 libdbus-1-3 libnss3 libnspr4 libatk-bridge2.0-0 \
+            libdrm2 libxkbcommon0 libatspi2.0-0 libcups2 libxshmfence1 libgbm1 \
+            fonts-noto-cjk fonts-noto-color-emoji \
+            2>&1 && \
+          cp -a /usr/lib/x86_64-linux-gnu/. /chrome-libs/ && \
+          cp -a /usr/share/fonts/. /chrome-fonts/ && \
+          cp -a /etc/fonts/. /chrome-fontconfig/ && \
+          echo "Chrome dependencies and CJK fonts installed"
+        volumeMounts:
+        - name: chrome-libs
+          mountPath: /chrome-libs
+        - name: chrome-fonts
+          mountPath: /chrome-fonts
+        - name: chrome-fontconfig
+          mountPath: /chrome-fontconfig
+      {{- end }}
+
       containers:
       - name: main
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -99,12 +130,14 @@ spec:
           failureThreshold: 30
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
-        {{- if .Values.env }}
         env:
+        {{- if .Values.config.browser.enabled }}
+        - name: LD_LIBRARY_PATH
+          value: /chrome-libs
+        {{- end }}
         {{- range $key, $value := .Values.env }}
         - name: {{ $key }}
           value: {{ $value | quote }}
-        {{- end }}
         {{- end }}
         envFrom:
         {{- if .Values.gateway.token.generate }}
@@ -125,7 +158,15 @@ spec:
         - name: bash-aliases
           mountPath: /home/node/.bash_aliases
           subPath: bash_aliases
-      
+        {{- if .Values.config.browser.enabled }}
+        - name: chrome-libs
+          mountPath: /chrome-libs
+        - name: chrome-fonts
+          mountPath: /usr/share/fonts
+        - name: chrome-fontconfig
+          mountPath: /etc/fonts
+        {{- end }}
+
       volumes:
       - name: config
         configMap:
@@ -138,3 +179,11 @@ spec:
           claimName: {{ include "openclaw-helm.fullname" . }}
       - name: tmp
         emptyDir: {}
+      {{- if .Values.config.browser.enabled }}
+      - name: chrome-libs
+        emptyDir: {}
+      - name: chrome-fonts
+        emptyDir: {}
+      - name: chrome-fontconfig
+        emptyDir: {}
+      {{- end }}

--- a/charts/openclaw-helm/values.yaml
+++ b/charts/openclaw-helm/values.yaml
@@ -34,7 +34,8 @@ config:
   
   browser:
     enabled: false
-  
+    # Set to true to install Chrome/Chromium system libraries via init container
+
   agents:
     defaults:
       workspace: /home/node/.openclaw/workspace
@@ -77,6 +78,9 @@ gateway:
   token:
     generate: true    # auto-generate gateway token Secret on install, retained on uninstall
     secretName: ""    # override secret name if generate=false
+
+browser:
+  depsImage: debian:12
 
 env: {}
   # EXAMPLE_VAR: "value"


### PR DESCRIPTION
When config.browser.enabled is true, adds an init container that installs Chrome system libraries and CJK fonts into shared emptyDir volumes, and sets LD_LIBRARY_PATH in the main container.