### PR TITLE
fix: stop ignoring tracked helm charts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .DS_Store
 *.tgz
-charts/


### PR DESCRIPTION
## Summary
- remove the overly broad `charts/` ignore rule
- allow the bump workflow to stage Helm chart source changes normally

## Why
The scheduled bump workflow was failing in the `Commit, tag and push` step because `charts/openclaw-helm/Chart.yaml` and `values.yaml` were ignored by `.gitignore`.

## Validation
- verified `git check-ignore` previously matched the root `.gitignore` rule `charts/`
- after this change, Helm chart files can be staged normally
