### PR TITLE
feat: add configmap checksum and pod scheduling support

### DIFF
--- a/charts/openclaw-helm/templates/deployment.yaml
+++ b/charts/openclaw-helm/templates/deployment.yaml
@@ -11,6 +11,8 @@ spec:
       {{- include "openclaw-helm.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         {{- include "openclaw-helm.selectorLabels" . | nindent 8 }}
     spec:
@@ -126,6 +128,18 @@ spec:
           mountPath: /home/node/.bash_aliases
           subPath: bash_aliases
       
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
       - name: config
         configMap:

--- a/charts/openclaw-helm/values.yaml
+++ b/charts/openclaw-helm/values.yaml
@@ -89,3 +89,9 @@ env: {}
 #   - configMapRef:
 #       name: openclaw-config
 envFrom: []
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
## Summary
- Add `checksum/config` annotation to pod template so ConfigMap changes trigger automatic pod restarts
- Add `nodeSelector`, `tolerations`, and `affinity` fields for flexible pod scheduling on multi-node clusters

## Test plan
- [ ] `helm template` renders checksum annotation correctly
- [ ] Scheduling fields are hidden when empty (default)
- [ ] Scheduling fields render correctly when values are provided
- [ ] Existing deployments upgrade without issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)