### PR TITLE
fix: sync gateway tokens in init-config to prevent token mismatch after pod restart

### DIFF
--- a/charts/openclaw-helm/templates/deployment.yaml
+++ b/charts/openclaw-helm/templates/deployment.yaml
@@ -22,28 +22,17 @@ spec:
         - -c
         - |
           mkdir -p /home/node/.openclaw
-          IS_FRESH=false
-          if [ ! -f /home/node/.openclaw/openclaw.json ]; then
-            cp /config/openclaw.json /home/node/.openclaw/openclaw.json
-            IS_FRESH=true
-          fi
-          # Sync gateway tokens to match OPENCLAW_GATEWAY_TOKEN (if set)
-          # - Fresh install: only set remote.token (do not persist auth.token; gateway uses env var)
-          # - Existing install: sync both auth.token + remote.token for backward compatibility
+          [ -f /home/node/.openclaw/openclaw.json ] || cp /config/openclaw.json /home/node/.openclaw/openclaw.json
+          # Sync gateway.remote.token to match OPENCLAW_GATEWAY_TOKEN (if set)
+          # gateway reads auth token from env var first (env-first precedence), so auth.token in config is not needed
           if [ -n "$OPENCLAW_GATEWAY_TOKEN" ]; then
             node -e "
               const fs = require('fs');
               const p = '/home/node/.openclaw/openclaw.json';
               const c = JSON.parse(fs.readFileSync(p));
-              const token = process.env.OPENCLAW_GATEWAY_TOKEN;
-              const isFresh = process.env.IS_FRESH === 'true';
               c.gateway = c.gateway || {};
               c.gateway.remote = c.gateway.remote || {};
-              c.gateway.remote.token = token;
-              if (!isFresh) {
-                c.gateway.auth = c.gateway.auth || {};
-                c.gateway.auth.token = token;
-              }
+              c.gateway.remote.token = process.env.OPENCLAW_GATEWAY_TOKEN;
               fs.writeFileSync(p, JSON.stringify(c, null, 2));
             "
           fi


### PR DESCRIPTION
Closes #22

## The Problem (Issue #22)

On a **fresh Helm install**, the init container copies `openclaw.json` from the ConfigMap (which is rendered from `.Values.config` in `values.yaml`) onto the PVC. The gateway starts fine.

But after a **pod restart**, the init container skips the copy (file already exists on PVC), so `gateway.remote.token` stays stale or unset — while the gateway process always reads its auth token fresh from `OPENCLAW_GATEWAY_TOKEN` env var.

```
  Fresh install
  ┌──────────────────────────────────────────────────────┐
  │ init-config                                          │
  │  openclaw.json not on PVC                            │
  │  → copy from ConfigMap (rendered from values.yaml)   │
  └──────────────────────────────────────────────────────┘
           │                          │
           ▼                          ▼
  ┌─────────────────┐        ┌─────────────────┐
  │ gateway process │        │  openclaw CLI   │
  │ auth = PGdODrQd │  ✓ ok  │ remote = PGdODrQd│
  │ (env var)       │        │ (from PVC)      │
  └─────────────────┘        └─────────────────┘

  After pod restart
  ┌──────────────────────────────────────────────────────┐
  │ init-config                                          │
  │  openclaw.json already on PVC → SKIP                 │
  │  gateway.remote.token = (stale / missing)            │
  └──────────────────────────────────────────────────────┘
           │                          │
           ▼                          ▼
  ┌─────────────────┐        ┌─────────────────┐
  │ gateway process │        │  openclaw CLI   │
  │ auth = PGdODrQd │  ✗     │ remote = stale  │
  │ (env var)       │        │ (from PVC)      │
  └─────────────────┘        └─────────────────┘
           └──────── token mismatch ──┘
```

## Why Only `remote.token` Needs Syncing

The gateway resolves its own auth token with **env-first precedence**:

```
  OPENCLAW_GATEWAY_TOKEN (env)  ←── always wins
           │
           ▼
  gateway.auth.token (config)   ←── only used if env var absent
```

So `gateway.auth.token` in `openclaw.json` is irrelevant when `OPENCLAW_GATEWAY_TOKEN` is set. Only the **CLI** needs `gateway.remote.token` in config to know what token to present.

## The Fix (This PR)

Run the sync on **every pod start**, not just first start:

```
  Every pod start
  ┌─────────────────────────────────────────────────────┐
  │ init-config                                         │
  │  1. copy openclaw.json if not on PVC (unchanged)    │
  │  2. if OPENCLAW_GATEWAY_TOKEN set:                  │
  │       gateway.remote.token = OPENCLAW_GATEWAY_TOKEN │
  └─────────────────────────────────────────────────────┘
           │                          │
           ▼                          ▼
  ┌─────────────────┐        ┌─────────────────┐
  │ gateway process │        │  openclaw CLI   │
  │ auth = PGdODrQd │  ✓ ok  │ remote = PGdODrQd│
  │ (env var)       │        │ (synced)        │
  └─────────────────┘        └─────────────────┘
           └──────────── match ✓ ─────┘
```

Non-Helm deployments are unaffected — the sync block is guarded by `[ -n "$OPENCLAW_GATEWAY_TOKEN" ]`.

## Impact

| Deployment | Impact |
|---|---|
| Helm with `OPENCLAW_GATEWAY_TOKEN` | ✅ `remote.token` synced on every pod start |
| Helm without `OPENCLAW_GATEWAY_TOKEN` | ✅ No change |
| Non-Helm (binary) | ✅ No change |

## Note: This is a Helm-layer Workaround

The root cause is an asymmetry in the upstream codebase: the gateway reads its auth token from env var, while the CLI reads it from `openclaw.json`. The proper fix would be for the CLI to also prefer `OPENCLAW_GATEWAY_TOKEN` over `gateway.remote.token` in config (env-first on the client side), eliminating the need for any sync logic here.

This PR patches the problem at the Helm layer until upstream adopts that approach. The sync script can be removed from this chart once the upstream CLI supports env-first credential resolution.
