### PR TITLE
docs: persist GitHub CLI auth config under .openclaw

### DIFF
--- a/docs/persistent-tools.md
+++ b/docs/persistent-tools.md
@@ -103,7 +103,17 @@ OpenClaw will run the command, capture the one-time code and URL, and send them 
 
 ### GitHub CLI example (`gh auth login`)
 
-A concrete example for GitHub CLI when you can only interact with the OpenClaw agent inside the Pod:
+A concrete example for GitHub CLI when you can only interact with the OpenClaw agent inside the Pod. In addition to persisting the `gh` binary under `~/.openclaw/workspace/bin/gh`, you should also persist the GitHub CLI config/auth directory.
+
+Before running `gh auth login`, use:
+
+```bash
+export PATH=/home/node/.openclaw/workspace/bin:$PATH
+export GH_CONFIG_DIR=/home/node/.openclaw/.config/gh
+mkdir -p /home/node/.openclaw/.config/gh
+```
+
+This ensures the OAuth token is written under the persisted `~/.openclaw` path instead of the default ephemeral `~/.config/gh`.
 
 Ask OpenClaw:
 


### PR DESCRIPTION
## Summary

Follow up on the earlier device-flow doc by documenting the missing persistence detail for GitHub CLI auth.

## What changed

- added `GH_CONFIG_DIR=/home/node/.openclaw/.config/gh`
- added `mkdir -p /home/node/.openclaw/.config/gh`
- clarified that the `gh` binary and the `gh` auth/config directory must both live under persisted `~/.openclaw`
- explained why default `~/.config/gh` is not sufficient in this Pod model

## Why

Persisting only the `gh` binary is not enough. By default, `gh` stores auth under `~/.config/gh`, which may be outside the persisted PVC path. This doc update makes the persistence model explicit and avoids confusing re-login behavior.
