### PR TITLE
docs: note GH_CONFIG_DIR in ~/.openclaw/.env

### DIFF
--- a/docs/persistent-tools.md
+++ b/docs/persistent-tools.md
@@ -115,6 +115,14 @@ mkdir -p /home/node/.openclaw/.config/gh
 
 This ensures the OAuth token is written under the persisted `~/.openclaw` path instead of the default ephemeral `~/.config/gh`.
 
+If your OpenClaw environment automatically loads `~/.openclaw/.env`, you can make this persistent across future sessions by adding:
+
+```bash
+GH_CONFIG_DIR=/home/node/.openclaw/.config/gh
+```
+
+That way, future `gh` commands will keep using the cached token without requiring a manual `export` each time.
+
 Ask OpenClaw:
 
 > can you run like this and tell me the OTP?  


### PR DESCRIPTION
## Summary

Document that users can place `GH_CONFIG_DIR=/home/node/.openclaw/.config/gh` in `~/.openclaw/.env` when their OpenClaw environment auto-loads that file.

## What changed

- added a note under the GitHub CLI device-flow section
- showed the exact `.env` entry
- explained that this avoids needing to manually export `GH_CONFIG_DIR` every time

## Why

The prior doc explains where `gh` auth should be stored, but not how to make that config path apply automatically in future sessions. This note closes that loop for environments that auto-load `~/.openclaw/.env`.
