### PR TITLE
fix: correct secretKeyRef.key to match generated Secret key name

### DIFF
--- a/charts/openclaw-helm/templates/deployment.yaml
+++ b/charts/openclaw-helm/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
               {{- else }}
               name: {{ .Values.gateway.token.secretName }}
               {{- end }}
-              key: token
+              key: OPENCLAW_GATEWAY_TOKEN
               optional: true
         volumeMounts:
         - name: config


### PR DESCRIPTION
Fixes #34

## Problem

The Secret template stores the gateway token under key `OPENCLAW_GATEWAY_TOKEN`:

```yaml
# templates/secret.yaml
data:
  OPENCLAW_GATEWAY_TOKEN: {{ randAlphaNum 32 | b64enc | quote }}
```

But `init-config` was reading it with `secretKeyRef.key: token` — so `$OPENCLAW_GATEWAY_TOKEN` was always empty in the init container. The sync condition `[ -n "$OPENCLAW_GATEWAY_TOKEN" ]` was always false, meaning `gateway.remote.token` in `openclaw.json` on the PVC was **never updated** after pod restarts.

This silently broke the PR #23 fix, causing `token mismatch (1008)` errors on every agent tool call after a pod restart.

## Fix

Change `secretKeyRef.key` from `token` → `OPENCLAW_GATEWAY_TOKEN` to match the actual Secret key generated by `templates/secret.yaml`.

```diff
- key: token
+ key: OPENCLAW_GATEWAY_TOKEN
```

## Notes

- This fix applies to the default `gateway.token.generate: true` path, where the Secret key is always `OPENCLAW_GATEWAY_TOKEN`.
- Users using `gateway.token.secretName` (BYO secret) must ensure their Secret also uses `OPENCLAW_GATEWAY_TOKEN` as the key name, or the sync will silently skip (due to `optional: true`).
